### PR TITLE
Disable reverse lookup

### DIFF
--- a/listen_on_all_addresses.cnf
+++ b/listen_on_all_addresses.cnf
@@ -1,2 +1,3 @@
 [mysqld]
 bind-address = 0.0.0.0
+skip-name-resolve


### PR DESCRIPTION
Reverse lookup in Docker at least for local clients isn't working anyways.
